### PR TITLE
Add sanity check to audio files

### DIFF
--- a/errors.py
+++ b/errors.py
@@ -18,3 +18,15 @@ class FfmpegValidationError(Exception):
     Exception object that is raised when `ffmpeg` output does not validate.
     """
     pass
+
+class FfmpegIncorrectDurationError(FfmpegValidationError):
+    """
+    Exception object that is raised when `ffmpeg` output does not validate.
+    """
+    def __init__(self, filepath, target_duration, actual_duration, *args):
+        self.filepath = filepath
+        self.target_duration = target_duration
+        self.actual_duration = actual_duration
+        msg = "Output at {} was expected to be duration {} seconds, but got {} seconds"
+        msg = msg.format(filepath, target_duration, actual_duration)
+        super(FfmpegIncorrectDurationError, self).__init__( msg, *args)

--- a/errors.py
+++ b/errors.py
@@ -1,0 +1,20 @@
+class SubprocessError(Exception):
+    """
+    Exception object that contains information about an error that occurred
+    when running a command line command with a subprocess.
+    """
+    def __init__(self, cmd, return_code, stdout, stderr, *args):
+        msg = 'Got non-zero exit code ({1}) from command "{0}": {2}'
+        msg = msg.format(cmd[0], return_code, stderr)
+        self.cmd = cmd
+        self.cmd_return_code = return_code
+        self.cmd_stdout = stdout
+        self.cmd_stderr = stderr
+        super(SubprocessError, self).__init__(msg, *args)
+
+
+class FfmpegValidationError(Exception):
+    """
+    Exception object that is raised when `ffmpeg` output does not validate.
+    """
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 youtube-dl==2017.9.15
 pafy==0.5.3.1
 multiprocessing-logging==0.2.4
+sox==1.3.0

--- a/utils.py
+++ b/utils.py
@@ -1,23 +1,10 @@
 import os
-import subprocess as sp
 import re
+import subprocess as sp
+
+from errors import SubprocessError
 
 URL_PATTERN = re.compile(r'https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)')
-
-
-class SubprocessError(Exception):
-    """
-    Exception object that contains information about an error that occurred
-    when running a command line command with a subprocess.
-    """
-    def __init__(self, cmd, return_code, stdout, stderr, *args):
-        msg = 'Got non-zero exit code ({1}) from command "{0}": {2}'
-        msg = msg.format(cmd[0], return_code, stderr)
-        self.cmd = cmd
-        self.cmd_return_code = return_code
-        self.cmd_stdout = stdout
-        self.cmd_stderr = stderr
-        super(SubprocessError, self).__init__(msg, *args)
 
 
 def run_command(cmd, **kwargs):

--- a/validation.py
+++ b/validation.py
@@ -1,9 +1,10 @@
+import os.path
 import sox
 
-from errors import FfmpegValidationError
+from errors import FfmpegValidationError, FfmpegIncorrectDurationError
 
 
-def sanity_check_audio(audio_filepath, audio_info):
+def validate_audio(audio_filepath, audio_info):
     """
     Take audio file and sanity check basic info.
 
@@ -19,32 +20,31 @@ def sanity_check_audio(audio_filepath, audio_info):
             }
 
     Args:
-        audio_filepath:  Path to output audio
-                         (Type: str)
+        audio_filepath:   Path to output audio
+                          (Type: str)
 
-        audio_info:      Audio info dict
-                         (Type: dict[str, *])
+        audio_info:       Audio info dict
+                          (Type: dict[str, *])
 
     Returns:
         check_passed:  True if sanity check passed
                        (Type: bool)
     """
+    if not os.path.exists(audio_filepath):
+        error_msg = 'Output file {} does not exist.'.format(audio_filepath)
+        raise FfmpegValidationError(error_msg)
 
     sox_info = sox.file_info.info(audio_filepath)
-    return all([v == sox_info[k] for k, v in audio_info.items()])
 
-
-def validate_audio(audio_filepath, audio_info):
-    """
-    Validate output audio from `ffmpeg`
-
-    Args:
-        audio_filepath:  Path to output audio
-                         (Type: str)
-
-        audio_info:      Audio info dict
-                         (Type: dict[str, *])
-    """
-    if not sanity_check_audio(audio_filepath, audio_info):
-        error_msg = 'Audio {} is corrupted.'.format(audio_filepath)
-        raise FfmpegValidationError(error_msg)
+    # If duration specifically doesn't match, catch that separately so we can
+    # retry with a different duration
+    target_duration = audio_info['duration']
+    actual_duration = sox_info['num_samples'] / audio_info['sample_rate']
+    if target_duration != actual_duration:
+        raise FfmpegIncorrectDurationError(audio_filepath, target_duration,
+                                           actual_duration)
+    for k, v in audio_info.items():
+        output_v = sox_info[k]
+        if v != output_v:
+            error_msg = 'Output audio {} should have {} = {}, but got {}.'.format(audio_filepath, k, v, output_v)
+            raise FfmpegValidationError(error_msg)

--- a/validation.py
+++ b/validation.py
@@ -1,0 +1,50 @@
+import sox
+
+from errors import FfmpegValidationError
+
+
+def sanity_check_audio(audio_filepath, audio_info):
+    """
+    Take audio file and sanity check basic info.
+
+        Sample output from sox:
+            {
+                'bitrate': 16,
+                'channels': 2,
+                'duration': 9.999501,
+                'encoding': 'FLAC',
+                'num_samples': 440978,
+                'sample_rate': 44100.0,
+                'silent': False
+            }
+
+    Args:
+        audio_filepath:  Path to output audio
+                         (Type: str)
+
+        audio_info:      Audio info dict
+                         (Type: dict[str, *])
+
+    Returns:
+        check_passed:  True if sanity check passed
+                       (Type: bool)
+    """
+
+    sox_info = sox.file_info.info(audio_filepath)
+    return all([v == sox_info[k] for k, v in audio_info.items()])
+
+
+def validate_audio(audio_filepath, audio_info):
+    """
+    Validate output audio from `ffmpeg`
+
+    Args:
+        audio_filepath:  Path to output audio
+                         (Type: str)
+
+        audio_info:      Audio info dict
+                         (Type: dict[str, *])
+    """
+    if not sanity_check_audio(audio_filepath, audio_info):
+        error_msg = 'Audio {} is corrupted.'.format(audio_filepath)
+        raise FfmpegValidationError(error_msg)


### PR DESCRIPTION
This PR is to add a sanity check to audio.

I have created a sanity check function using sox which will check duration, # channels, bitrates, and codec. However, I noticed that there are some audios not exactly 10.0 seconds after FFmpeg (they are all around 9.999x - 10.000x). We would need to loosen the check a little bit.

The other thing is I am not super sure once we found a corrupted audio, how do we trigger the retry. My idea to implement it deep in the `download_yt_video` function is that whenever we see a failure, we can yield an error message and hopefully the subprocess will re-try it. @jtcramer you will know better how to handle the error message properly. Feel free to push to this PR directly or comment on and I will fix that.

Let me know if this makes sense.